### PR TITLE
Add (video|audio).load()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -235,6 +235,7 @@ class AsyncPreloader {
 			video.addEventListener("canplaythrough", () => resolve(video), false);
 			video.addEventListener("error", reject, false);
 			video.src = URL.createObjectURL(data);
+			video.load();
 		});
 	};
 
@@ -261,6 +262,7 @@ class AsyncPreloader {
 		audio.autoplay = false;
 		audio.preload = "auto";
 		audio.src = URL.createObjectURL(data);
+		audio.load();
 
 		return await new Promise<HTMLAudioElement>((resolve, reject) => {
 			audio.addEventListener("canplaythrough", () => resolve(audio), false);


### PR DESCRIPTION
Fixes https://github.com/dmnsgn/async-preloader/issues/9.
Possibly fixes https://github.com/dmnsgn/async-preloader/issues/4 too.

The problem is caused by `canplaythrough` not being fired on iOS Safari as discussed [here](https://stackoverflow.com/questions/49792768/js-html5-audio-why-is-canplaythrough-not-fired-on-ios-safari). 